### PR TITLE
fix: rename environment variables

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,8 +30,8 @@ JSON_DATA=$(jq -n -c \
 
 echo $JSON_DATA
 
-response_code=$(curl --show-error --silent --location --request POST "${CI_ENDPOINT}/migration/run" --write-out "%{http_code}" \
---header "Verification-Token: ${SECRET_TOKEN}" \
+response_code=$(curl --show-error --silent --location --request POST "${DLMC_CI_ENDPOINT}/migration/run" --write-out "%{http_code}" \
+--header "Verification-Token: ${DLMC_VERIFICATION_TOKEN}" \
 --header 'Content-Type: application/json' \
 --output response.json \
 --data "${JSON_DATA}")
@@ -63,8 +63,8 @@ fi
 mkdir artifacts
 
 download_artifacts() {
-    artifact_code=$(curl --show-error --silent "${CI_ENDPOINT}/artifact/download?artifact_type=$1&session_id=$2&clone_id=$3" --write-out "%{http_code}" \
-         --header "Verification-Token: ${SECRET_TOKEN}" \
+    artifact_code=$(curl --show-error --silent "${DLMC_CI_ENDPOINT}/artifact/download?artifact_type=$1&session_id=$2&clone_id=$3" --write-out "%{http_code}" \
+         --header "Verification-Token: ${DLMC_VERIFICATION_TOKEN}" \
          --header 'Content-Type: application/json' \
          --output artifacts/$1)
 
@@ -81,8 +81,8 @@ cat response.json | jq -c -r '.session.artifacts[]' | while read artifact; do
 done
 
 # Stop the running clone
-response_code=$(curl --show-error --silent "${CI_ENDPOINT}/artifact/stop?clone_id=${clone_id}" --write-out "%{http_code}" \
-     --header "Verification-Token: ${SECRET_TOKEN}" \
+response_code=$(curl --show-error --silent "${DLMC_CI_ENDPOINT}/artifact/stop?clone_id=${clone_id}" --write-out "%{http_code}" \
+     --header "Verification-Token: ${DLMC_VERIFICATION_TOKEN}" \
      --header 'Content-Type: application/json')
 
 if [[ $response_code -ne 200 ]]; then


### PR DESCRIPTION
To make variables unique and avoid ambiguousness